### PR TITLE
Add support for Thunder task manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,9 @@ RUN set -xe; \
     \
     su - thunder --command="nvm install --lts node"; \
     \
-    su - thunder --command="npm config set update-notifier false" \
+    su - thunder --command="npm config set update-notifier false"; \
     \
-    apt-get list --installed | grep --only-matching '.*-dev' | xargs apt-get purge --yes; \
+    dpkg --get-selections | grep --only-matching '.*-dev' | xargs apt-get purge --yes; \
     \
     apt-get purge --yes gnupg apt-transport-https; \
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint ignore=DL3007
 FROM burda/thunder-php:latest
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -12,14 +13,12 @@ RUN set -xe; \
     usermod --append --groups sudo thunder;
 
 # Install required libraries and packages
+# hadolint ignore=DL3008
 RUN set -xe; \
     \
     apt-get update; \
     \
-    apt-get install --yes --no-install-recommends \
-        gnupg \
-        apt-transport-https \
-    ; \
+    apt-get install --yes --no-install-recommends gnupg apt-transport-https; \
     \
     curl --silent --show-error https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - ; \
     \
@@ -27,9 +26,7 @@ RUN set -xe; \
     \
     apt-get update; \
     \
-    apt-get install --yes --no-install-recommends \
-        yarn \
-    ; \
+    apt-get install --yes --no-install-recommends yarn; \
     \
     su - thunder --command="curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash"; \
     \
@@ -37,12 +34,11 @@ RUN set -xe; \
     \
     su - thunder --command="nvm install --lts node"; \
     \
-    apt list --installed | grep --only-matching '.*-dev' | xargs apt-get purge --yes; \
+    su - thunder --command="npm config set update-notifier false" \
     \
-    apt purge --yes \
-        gnupg \
-        apt-transport-https \
-    ; \
+    apt-get list --installed | grep --only-matching '.*-dev' | xargs apt-get purge --yes; \
+    \
+    apt-get purge --yes gnupg apt-transport-https; \
     \
     apt-get clean; \
     \

--- a/scripts/docker/thunder-php-test
+++ b/scripts/docker/thunder-php-test
@@ -7,10 +7,11 @@ cd /home/thunder/www/docroot || exit 1
 echo 'Serving on: 0.0.0.0:8080 ...'
 php --server 0.0.0.0:8080 .ht.router.php &
 
-status=$?
-if [ $status -ne 0 ]; then
-  echo "Failed to start '.ht.router.php': $status"
-  exit $status
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo "Failed to start '.ht.router.php': ${STATUS}"
+
+    exit $STATUS
 fi
 
 while ! curl --output /dev/null --silent --head --fail http://localhost:8080; do
@@ -18,8 +19,5 @@ while ! curl --output /dev/null --silent --head --fail http://localhost:8080; do
 done
 
 cd /home/thunder/www/docroot/core || exit 1
-while true; do
-    yarn test:nightwatch --tag "${THUNDER_TEST_GROUP}"
 
-    sleep 10
-done
+yarn test:nightwatch --tag "${THUNDER_TEST_GROUP}"

--- a/scripts/docker/thunder-php-test
+++ b/scripts/docker/thunder-php-test
@@ -4,20 +4,23 @@
 
 cd /home/thunder/www/docroot || exit 1
 
-echo 'Serving on: 0.0.0.0:8080 ...'
+echo "Serving on: 0.0.0.0:8080 ..."
 php --server 0.0.0.0:8080 .ht.router.php &
 
 STATUS=$?
-if [ $STATUS -ne 0 ]; then
+echo "Server started with status: ${STATUS}"
+if [ "${STATUS}" != "0" ]; then
     echo "Failed to start '.ht.router.php': ${STATUS}"
 
     exit $STATUS
 fi
 
-while ! curl --output /dev/null --silent --head --fail http://localhost:8080; do
+echo "Wait for Drupal to be ready..."
+while ! curl --output /dev/null --silent --head --fail "http://localhost:8080"; do
     sleep 1
 done
 
 cd /home/thunder/www/docroot/core || exit 1
 
+echo "Starting tests..."
 yarn test:nightwatch --tag "${THUNDER_TEST_GROUP}"


### PR DESCRIPTION
This PR contains the following changes:
1. Remove loop for tests, so that test is executed only once because we will start to use warmed up docker containers
2. Fixed issue with the termination of docker container because of `npm` update notifier
3. Dockerfile coding styles applied for hadolint
4. Improved logging in `thunder-php-test` for better debugging